### PR TITLE
Configurable Log Levels

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -116,6 +116,7 @@ services:
       - HWI_GPIO_SERIAL=/dev/ttyS0
       - HWI_USB_SERIAL=/dev/ttyUSB0
       - HWI_LOGS=/app/instance/logs
+      - HWI_LOG_LEVEL=INFO
       - HWI_CERTS=/app/instance/certs
       - LOKI_ENDPOINT="http://loki:3100/loki/api/v1/push"
     labels:

--- a/hwi/__main__.py
+++ b/hwi/__main__.py
@@ -78,10 +78,6 @@ def device_certs_handler(base_path: str) -> None:
     os.environ['AMQP_USER'] = config.get('amqp', 'user')
     os.environ['AMQP_PASS'] = config.get('amqp', 'password')
 
-_log = logging.getLogger(__name__)
-_log.info("HWI Logs: %s", os.environ.get("HWI_LOGS"))
-_log.info("HWI Certs: %s", os.environ.get("HWI_CERTS"))
-
 logging_handler(
     config_path=Path(__file__).parent.joinpath("logs/config/config.yaml"),
     base_path=os.environ.get("HWI_LOGS", str(Path(__file__).parent.joinpath('logs/')))
@@ -90,6 +86,10 @@ device_certs_handler(
     base_path=os.environ.get("HWI_CERTS", str(
         Path(__file__).parent.parent.joinpath('instance/certs')))
 )
+
+_log = logging.getLogger(__name__)
+_log.info("HWI Logs: %s", os.environ.get("HWI_LOGS"))
+_log.info("HWI Certs: %s", os.environ.get("HWI_CERTS"))
 
 RotaryEncoder()
 _log.info("Bound rotary encoder")

--- a/hwi/__main__.py
+++ b/hwi/__main__.py
@@ -11,7 +11,6 @@ import sys
 import os
 import logging
 import logging.config
-import coloredlogs
 from pathlib import Path
 from envyaml import EnvYAML
 from configparser import ConfigParser
@@ -31,6 +30,9 @@ def logging_handler(config_path: Path, base_path: str) -> None:
     :param base_path: logging path
     :type base_path: str
     """
+    # set default log level if undef
+    if not os.environ.get('HWI_LOG_LEVEL'):
+        os.environ['HWI_LOG_LEVEL'] = "INFO"
     os.makedirs(base_path, mode=0o777, exist_ok=True)
     # using split '.' to remove logs for rolling file handlers with format: <name>.log.<number>
     logs = list(
@@ -77,7 +79,6 @@ def device_certs_handler(base_path: str) -> None:
     os.environ['AMQP_PASS'] = config.get('amqp', 'password')
 
 _log = logging.getLogger(__name__)
-coloredlogs.install(level="DEBUG", logger=_log)
 _log.info("HWI Logs: %s", os.environ.get("HWI_LOGS"))
 _log.info("HWI Certs: %s", os.environ.get("HWI_CERTS"))
 

--- a/hwi/logs/config/config.yaml
+++ b/hwi/logs/config/config.yaml
@@ -3,44 +3,47 @@ version: 1
 disable_existing_loggers: false
 loggers:
   __main__:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
+  hwi.sys:
+    level: ${HWI_LOG_LEVEL}
+    handlers: ["loki_handler", "file_handler"]
+    propagate: false
   hwi.alink:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
     propagate: false
   hwi.icb:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
     propagate: false
   hwi.models:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
     propagate: false
   hwi.events:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
     propagate: false
   hwi.amqp:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
     propagate: false
   hwi.microscope:
-    level: "DEBUG"
+    level: ${HWI_LOG_LEVEL}
     handlers: ["loki_handler", "file_handler"]
     propagate: false
-  urllib:
+  urllib3:
     level: "WARNING"
     handlers: ["loki_handler", "file_handler"]
     propagate: false
   pika:
-    level: "INFO"
+    level: "WARNING"
     handlers: ["loki_handler", "file_handler"]
     propagate: false
 
 handlers:
   file_handler:
-    level: "DEBUG"
     class: "logging.handlers.RotatingFileHandler"
     formatter: default
     filename: ${HWI_LOGS}/hwi.log
@@ -48,7 +51,6 @@ handlers:
     maxBytes: 1000000
     backupCount: 10
   loki_handler:
-    level: "DEBUG"
     class: "logging_loki.LokiHandler"
     url: ${LOKI_ENDPOINT}
     tags:


### PR DESCRIPTION
# Description
Add environment variable `HWI_LOG_LEVEL` for hwi process logging. Configurable values match python logging level api strings: `INFO`, `DEBUG`, `WARNING`, `CRITICAL`, `ERROR`. The updated compose stack service integration is shown below:

```yaml
  hwi:
    container_name: hwi
    privileged: true
    depends_on:
      - rmq
    build:
      context: ../../
      dockerfile: docker/dev/Dockerfile
    volumes:
      - ../../:/app
      - /sys:/sys
    devices:
      - "/dev/ttyS0:/dev/ttyS0"
      - "/dev/ttyUSB0:/dev/ttyUSB0"
      - "/dev/gpiomem:/dev/gpiomem"
    networks:
      - amqp
      - monitor
    environment:
      - RABBITMQ_ADDR=rmq:5672
      - HWI_GPIO_SERIAL=/dev/ttyS0
      - HWI_USB_SERIAL=/dev/ttyUSB0
      - HWI_LOGS=/app/instance/logs
      - HWI_LOG_LEVEL=INFO
      - HWI_CERTS=/app/instance/certs
      - LOKI_ENDPOINT="http://loki:3100/loki/api/v1/push"
    labels:
      org.label-schema.group: "core"
```

## Resolutions
 - [x] Fixed logging config for `urllib`
 - [x] Moved all logging init after configuration
 - [x] Dynamic logging level config through `HWI_LOG_LEVEL` environment variable

